### PR TITLE
Change Scalate working dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+classes
 hive-conf
 site
 src/main/resources/*-site.xml

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -59,6 +59,7 @@ case ${COMPONENT} in
                 sed -i -E 's/([[:alpha:]\.]+)\="(true|false)"/\1\=\2/g' runtime.conf
                 sed -i -E 's/([[:alpha:]\.]+)\="[:digit:]+"/\1\=\2/g' runtime.conf
                 exec $JAVA_HOME/bin/java -Djavax.security.auth.useSubjectCredsOnly=false \
+                          -Dscalate.workdir=. \ 
                           -Djava.security.auth.login.config="${CONF_DIR}/jaas.conf" \
                           -Dconfig.resource=production.conf \
                           -Dlog4j.properties=file:"${CONF_DIR}/log4j.properties" \


### PR DESCRIPTION
The default working dir of Scalate is /tmp which can be cleaned up after
a long period of application uptime causing the application to cease
functioning.