### PR TITLE
Fix compliance type mapping

### DIFF
--- a/provisioning/src/main/scala/io/phdata/provisioning/HiveDatabaseRegistrationProvisioning.scala
+++ b/provisioning/src/main/scala/io/phdata/provisioning/HiveDatabaseRegistrationProvisioning.scala
@@ -65,7 +65,7 @@ object HiveDatabaseRegistrationProvisioning extends LazyLogging {
     val compliance = workspaceRequest.compliance
     Map(
       "phi_data" -> compliance.phiData.toString,
-      "pci_data" -> compliance.phiData.toString,
+      "pci_data" -> compliance.pciData.toString,
       "pii_data" -> compliance.piiData.toString
     )
   }


### PR DESCRIPTION
PCI values were mapping to pii in Hive database properties