### PR TITLE
Use lookup client for looking up groups

### DIFF
--- a/common/src/main/scala/io/phdata/services/MemberServiceImpl.scala
+++ b/common/src/main/scala/io/phdata/services/MemberServiceImpl.scala
@@ -129,7 +129,7 @@ class MemberServiceImpl[F[_]](context: AppContext[F])(implicit val F: Effect[F])
                 _ <- context.provisioningLDAPClient
                   .removeUserFromGroup(reg.distinguishedName, memberRequest.distinguishedName)
                   .value
-                groupMembers <- context.provisioningLDAPClient.groupMembers(reg.distinguishedName)
+                groupMembers <- context.lookupLDAPClient.groupMembers(reg.distinguishedName)
                 _ <- if (groupMembers.map(_.distinguishedName).contains(memberRequest.distinguishedName)) {
                   logger.error(
                     s"[REMOVING MEMBER] ${memberRequest.distinguishedName} wasn't properly removed from ${registration


### PR DESCRIPTION
Lookup client can be pointed at an AD server where lookups are allowed,
sometimes a provisioning LDAP connection does not have lookup ability