### PR TITLE
Remove 's' flag which breaks Firefox

### DIFF
--- a/ui/containers/WorkspaceDetails/constants.ts
+++ b/ui/containers/WorkspaceDetails/constants.ts
@@ -3,4 +3,4 @@ export enum ShowTypes {
   Groups = 'Groups',
 }
 
-export const distinguishedNameRegEx = /(?=.*?(CN=))(?=.*?(OU=))(?=.*?(DC=))/is;
+export const distinguishedNameRegEx = /(?=.*?(CN=))(?=.*?(OU=))(?=.*?(DC=))/i;


### PR DESCRIPTION
It's not necessary to match across newlines for distinguished names
anyways