### PR TITLE
Set default core value

### DIFF
--- a/common/src/main/scala/io/phdata/repositories/WorkspaceRequestRepositoryImpl.scala
+++ b/common/src/main/scala/io/phdata/repositories/WorkspaceRequestRepositoryImpl.scala
@@ -244,7 +244,7 @@ class WorkspaceRequestRepositoryImpl(sqlSyntax: SqlSyntax) extends WorkspaceRequ
                    else null
                    end                as fullyApproved,
                COALESCE(db.total_size, 0.0) as allocatedInGB,
-               res.cores              as maxCores,
+               COALESCE(res.cores, 0.0)     as maxCores,
                COALESCE(res.mem, 0.0) as maxMemoryInGB
         from workspace_request wr
                  inner join compliance c on wr.compliance_id = c.id


### PR DESCRIPTION
Without a default value the queries fail if a yarn queue creation fails