### PR TITLE
ARCH-690 Adding member with privelege 'NONE' fails

### DIFF
--- a/ui/containers/WorkspaceDetails/sagas.ts
+++ b/ui/containers/WorkspaceDetails/sagas.ts
@@ -216,7 +216,9 @@ export function* simpleMemberRequested({ resource }: SimpleMemberRequestAction) 
           distinguishedName = [...users, ...groups].filter(member => member.display === distinguishedName.trim())[0]
             .distinguished_name;
         }
-        workspaceMemberList.push({ resource, resource_id: id, role, distinguished_name: distinguishedName });
+        if (role !== 'none') {
+          workspaceMemberList.push({ resource, resource_id: id, role, distinguished_name: distinguishedName });
+        }
       });
 
       if (workspaceMemberList && workspaceMemberList.length) {


### PR DESCRIPTION
@afoerster If the permission is NONE we are removing from request object